### PR TITLE
Set `url` and `identifier` in disqus

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -36,6 +36,11 @@ layout: secondary
       </div>
     </div>
     <script type="text/javascript">
+        var disqus_config = function () {
+            this.page.url = '{{ site.url }}{{ page.url }}';
+            this.page.identifier = '{{ page.id }}';
+        };
+
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
         var disqus_shortname = 'obshq'; // required: replace example with your forum shortname
         /* * * DON'T EDIT BELOW THIS LINE * * */


### PR DESCRIPTION
When `url` and `identifier` are not defined, the Disqus embed use the window URL as identifier when creating a thread, which is causing duplicate "split threads". :bowtie: 

I am not sure if this will remove the old comments, but it will avoid the "split threads" in the feature. 🤔 

More info:
https://help.disqus.com/customer/en/portal/articles/2158629