### PR TITLE
Mark post mortems as 'deployments' blog posts

### DIFF
--- a/_posts/deployments/2017-07-04-post-mortem-1.html
+++ b/_posts/deployments/2017-07-04-post-mortem-1.html
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Post-mortem: Extended Deployment time on June 30, 2017"
-category: development
+category: deployments
 ---
 <p>
   On June 30, 2017 we had an extended deployment time of roughly 45 minutes for our

--- a/_posts/deployments/2017-07-19-post-mortem-2.html
+++ b/_posts/deployments/2017-07-19-post-mortem-2.html
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Post-mortem: Extended Deployment time on July 19, 2017"
-category: development
+category: deployments
 author: Björn Geuken
 
 ---

--- a/_posts/deployments/2017-08-28-post-mortem-3.html
+++ b/_posts/deployments/2017-08-28-post-mortem-3.html
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Post-mortem: Extended Deployment time on August 28, 2017"
-category: development
+category: deployments
 author: Manuel Schnitzer
 
 ---

--- a/_posts/deployments/2017-12-15-post-mortem-4.html
+++ b/_posts/deployments/2017-12-15-post-mortem-4.html
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Post-mortem: Deployment on December 14, 2017"
-category: development
+category: deployments
 author: Ana María Martínez Gómez
 
 ---


### PR DESCRIPTION
That way they are highlighted differently and thus easier to distinguish
from other topics.