### PR TITLE
 Use post excerpts in the blog post list

### DIFF
--- a/_includes/post-listing.html
+++ b/_includes/post-listing.html
@@ -12,7 +12,7 @@
       posted on {{ post.date | date_to_string: "ordinal" }}
     </div>
     <p class="post-description">
-      {{ post.excerpt | strip_html | truncatewords: 75 }}
+      {{ post.excerpt | strip_html }}
     </p>
     <a href="{{ post.url }}" class="ui right floated teal button">Read more...</a>
     <div class="clearfix"></div>

--- a/_includes/post-listing.html
+++ b/_includes/post-listing.html
@@ -11,9 +11,14 @@
       {% endif %}
       posted on {{ post.date | date_to_string: "ordinal" }}
     </div>
-    <p class="post-description">
-      {{ post.excerpt | strip_html }}
-    </p>
+
+    {{ post.excerpt |
+       replace: '<p>', '__p__' |
+       replace: '</p>', '__/p__' |
+       strip_html |
+       replace: '__p__', '<p class="post-description">' |
+       replace: '__/p__', '</p>' }}
+
     <a href="{{ post.url }}" class="ui right floated teal button">Read more...</a>
     <div class="clearfix"></div>
   </div>

--- a/_includes/post-listing.html
+++ b/_includes/post-listing.html
@@ -12,7 +12,7 @@
       posted on {{ post.date | date_to_string: "ordinal" }}
     </div>
     <p class="post-description">
-      {{ post.content | strip_html | truncatewords: 75 }}
+      {{ post.excerpt | strip_html | truncatewords: 75 }}
     </p>
     <a href="{{ post.url }}" class="ui right floated teal button">Read more...</a>
     <div class="clearfix"></div>

--- a/_posts/deployments/2017-08-28-post-mortem-3.html
+++ b/_posts/deployments/2017-08-28-post-mortem-3.html
@@ -3,7 +3,7 @@ layout: post
 title: "Post-mortem: Extended Deployment time on August 28, 2017"
 category: deployments
 author: Manuel Schnitzer
-
+excerpt_separator: <!--more-->
 ---
 <p>
   During deployment, we were facing some issues and build.opensuse.org was not accessible for a couple
@@ -12,6 +12,8 @@ author: Manuel Schnitzer
 <p>
   This sucks and that's why we want to give you some insight in what happened.
 </p>
+
+<!--more-->
 
 <h2>Problems/Timeline</h2>
 <h3>2017-08-23</h3>

--- a/_posts/development/2017-05-05-frontend-sprint-report-1.html
+++ b/_posts/development/2017-05-05-frontend-sprint-report-1.html
@@ -3,6 +3,7 @@ layout: post
 title: Highlights of the OBS frontend development – Sprint 15
 category: development
 author: Henne Vogelsang, Björn Geuken
+excerpt_separator: <!--more-->
 ---
 <p>
   This is the first in a series of posts in which the frontend hackers want
@@ -14,6 +15,8 @@ author: Henne Vogelsang, Björn Geuken
 <p>
   But first things first, let us introduce how we are getting to these results.
 </p>
+
+<!--more-->
 
 <h2>Our process: SCRUM</h2>
 

--- a/_posts/development/2017-08-18-sprint-report-22.md
+++ b/_posts/development/2017-08-18-sprint-report-22.md
@@ -6,6 +6,7 @@ category: development
 <p>
    Here are the results the OBS frontend team has achieved in the last two weeks (2017-08-07 to 2017-08-18).
 </p>
+
 <h2>Features</h2>
 <h3>LDAP support for our 2.8 release</h3>
 <p>

--- a/_posts/development/2017-12-20-summary-of-2017.md
+++ b/_posts/development/2017-12-20-summary-of-2017.md
@@ -3,10 +3,13 @@ layout: post
 title: Frontend Team's 2017
 author: Henne Vogelsang
 category: development
+excerpt_separator: <!--more-->
 ---
 The year is coming to an end, all the 🎁 lie under the 🎄 and the 🍾 is already cold for 🎆. Being the good agile folks that we are, we think this is the perfect time to reflect on 2017. On all the code, the bugs and fixes, features and refactorings, the tunes and adjustments we have introduced to our code base, process and tool belt. Not only to trace the steps of our journey, but also to get ideas how to become more effective in 2018.
 
 So let's look at some of the highlights that have happened this year. Bear with us, this is a very long post, but one worth reading, promised!
+
+<!--more-->
 
 ## January
 The year started off with some changes to the <a href="/team">team</a>, Evan joined mid-December 2016 so at beginning of this year he was still shiny and had this new developer smell we all like so much. Code wise the year kicked off with a Ruby 2.4 port, the introduction of property tests into our suite and a new API route to get the GPG key and SSL certificate for a project.

--- a/_posts/documentation/2017-05-15-creating-your-own-image-template.md
+++ b/_posts/documentation/2017-05-15-creating-your-own-image-template.md
@@ -3,6 +3,7 @@ layout: post
 title: Creating Your Own Image Template
 category: documentation
 author: Björn Geuken
+excerpt_separator: <!--more-->
 ---
 
 Are you considering to write your own image templates, but you don't know
@@ -11,6 +12,7 @@ how to start? You have come to the right place.
 In this short article you will learn to create you own image templates
 and how you can publish them.
 
+<!--more-->
 
 ## The Subproject
 

--- a/_posts/documentation/2018-05-09-container-building-and-distribution.md
+++ b/_posts/documentation/2018-05-09-container-building-and-distribution.md
@@ -2,6 +2,7 @@
 layout: post
 title: Introduction of the new OBS Container Registry
 category: documentation
+excerpt_separator: <!--more-->
 ---
 
 Did you know that OBS can not only build RPM packages and appliances but also container formats like docker?
@@ -11,6 +12,7 @@ But how can you make use of containers you build with OBS?
 We recently introduced our [https://registry.opensuse.org](https://registry.opensuse.org)!  
 Read on if you want to know more :+1:
 
+<!--more-->
 
 # How can you build containers with OBS?
 

--- a/_posts/releases/2018-03-19-release_of_obs_2.9.md
+++ b/_posts/releases/2018-03-19-release_of_obs_2.9.md
@@ -2,6 +2,7 @@
 layout: post
 title: Release of the Open Build Service, Version 2.9
 category: releases
+excerpt_separator: <!--more-->
 ---
 
 The Build Service Team is happy to announce the release of Open Build Service 2.9! :tada:
@@ -18,6 +19,8 @@ image from OBS to the Amazon Web Services (AWS). :cloud:
 We revamped our notification system, including RSS Feeds for user's notifications,
 [RabbitMQ support](http://openbuildservice.org/2018/02/12/rabbitmq-integration/),
 a nicer UI for the notifications page and much more.
+
+<!--more-->
 
 A more detailed list of what we ship :ship: in 2.9 can be found in our
 [release notes](https://github.com/openSUSE/open-build-service/blob/2.9/ReleaseNotes-2.9).


### PR DESCRIPTION
Using the post.content we are just render the first 75 words without taken into account if they include things like code and titles, which shouldn't be in the post description.

With post excerpts we can decided what is shown for every blog post (using the `<!--more-->` tag):
https://jekyllrb.com/docs/posts/#post-excerpts

This is how it looks like now: :tada: 
![image](https://user-images.githubusercontent.com/16052290/40910202-ce956b0c-67eb-11e8-86b0-a084da9f1d89.png)
