### PR TITLE
Fix blog post without description in blog posts list

### DIFF
--- a/_posts/development/2017-09-04-sprint-report-8.md
+++ b/_posts/development/2017-09-04-sprint-report-8.md
@@ -3,6 +3,9 @@ layout: post
 title: Highlights of the OBS frontend development – Sprint 23
 category: development
 ---
+<p>
+  Here are the results the OBS frontend team has achieved in the last two weeks (2017-08-21 to 2017-09-01).
+</p>
 
 <h2>OBS 2.8.3 Release</h2>
 

--- a/_posts/releases/2016-07-05-download-on-demand-feature.md
+++ b/_posts/releases/2016-07-05-download-on-demand-feature.md
@@ -2,6 +2,7 @@
 layout: post
 title: Download on Demand (DoD)
 category: releases
+excerpt_separator: ""
 ---
 
 ## Using Download on Demand (DoD) Feature

--- a/_posts/releases/2016-10-21-information-about-constraints-problems.md
+++ b/_posts/releases/2016-10-21-information-about-constraints-problems.md
@@ -2,6 +2,7 @@
 layout: post
 title: Identify constraint problems
 category: releases
+excerpt_separator: ""
 ---
 
 ### Blame the constraints!

--- a/_posts/releases/2017-03-14-osc-0.157.1-release.md
+++ b/_posts/releases/2017-03-14-osc-0.157.1-release.md
@@ -2,7 +2,8 @@
 layout: post
 title: new osc 0.157.1 release
 category: releases
-author: Marco Strigl 
+author: Marco Strigl
+excerpt_separator: ""
 ---
 
 ### osc 0.157.1 release


### PR DESCRIPTION
Add description to Sprint 23 & disable excerpts for blog posts without introduction :bowtie: 