### PR TITLE
Escape html in feed summary

### DIFF
--- a/_includes/rss-feed.rss
+++ b/_includes/rss-feed.rss
@@ -15,7 +15,7 @@
           <link href="{{ site.url }}{{ post.url }}/"/>
           <updated>{{ post.date | date_to_xmlschema }}</updated>
           <id>{{ site.url }}{{ post.url }}/</id>
-          <summary type="html">{{ post.content | strip_html | truncatewords: 75 | xml_escape }}</summary>
+          <summary type="html">{{ post.content | strip_html | truncatewords: 75 | emojify }}</summary>
       </entry>
     {% endfor %}
 </feed>

--- a/_includes/rss-feed.rss
+++ b/_includes/rss-feed.rss
@@ -15,7 +15,7 @@
           <link href="{{ site.url }}{{ post.url }}/"/>
           <updated>{{ post.date | date_to_xmlschema }}</updated>
           <id>{{ site.url }}{{ post.url }}/</id>
-          <summary type="html">{{ post.content | strip_html | truncatewords: 75 }}</summary>
+          <summary type="html">{{ post.content | strip_html | truncatewords: 75 | xml_escape }}</summary>
       </entry>
     {% endfor %}
 </feed>

--- a/_plugins/emojify.rb
+++ b/_plugins/emojify.rb
@@ -1,0 +1,17 @@
+require 'gemoji'
+
+module Jekyll
+  module EmojifyFilter
+    def emojify(input)
+      input.to_str.gsub(/:([\w+-]+):/) do |match|
+        if emoji = ::Emoji.find_by_alias($1)
+          emoji.raw unless emoji.custom?
+        else
+          match
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::EmojifyFilter)

--- a/feed.rss
+++ b/feed.rss
@@ -1,24 +1,4 @@
 ---
 layout: null
 ---
-<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-    <title type="text" xml:lang="en">{{ site.title }}</title>
-    <link type="application/atom+xml" href="{{ site.url }}/feed" rel="self" />
-    <link type="text" href="{{ site.url }}" rel="alternate" />
-
-    <updated>{{ site.time | date_to_xmlschema }}</updated>
-    <id>{{ site.url }}</id>
-    <author><name>OBS Team</name></author>
-    <rights>Copyright (c) 2012 OBS Team</rights>
-
-    {% for post in site.posts limit:10 %}
-      <entry>
-          <title>{{ post.title }}</title>
-          <link href="{{ site.url }}{{ post.url }}/"/>
-          <updated>{{ post.date | date_to_xmlschema }}</updated>
-          <id>{{ site.url }}{{ post.url }}/</id>
-          <summary type="html">{{ post.content | strip_html }}</summary>
-      </entry>
-    {% endfor %}
-</feed>
+{% include rss-feed.rss %}


### PR DESCRIPTION
That's according to atom spec, html should be escaped there