### PR TITLE
Fix typos in events-to-notifications blog post

### DIFF
--- a/_posts/development/2020-06-10-events-to-notifications.md
+++ b/_posts/development/2020-06-10-events-to-notifications.md
@@ -1,14 +1,14 @@
 ---
 layout: post
-title: From showing what happend, to showing what matters.
+title: From showing what happened, to showing what matters.
 category: development
 ---
 
 It's time again to talk about the notifications. On our journey to a full-fledged notification system,
-we put our emphasis on the content of the notifications itself and kept improving
+we put our emphasis on the content of the notifications and kept improving
 several UI parts to increase productivity and user experience.
 
-Until now, a notification just reflects the occurrence of an event in which you are involved.
+Until now, a notification just reflected the occurrence of an event in which you were involved.
 This can be a response to a comment, a open request that got accepted or a review that
 is wanted from you. The problem with showing a chronological list of events, do you still care about the state of your request from
 one week ago, that meanwhile changed four times?
@@ -16,7 +16,7 @@ Most likely not, that is why we worked hard to move from an event based flow, to
 system that only shows what really matters.
 Instead of producing new notification records for every single event, we keep notifications
 related to a certain notifiable(can be a comment or request) up-to-date. The review wanted notifications
-are now unified with the request one's. Since the current state is always reflected, it will reveal when a
+are now unified with the request ones. Since the current state is always reflected, it will reveal when a
 review is required by you or someone else.
 
 Badges are indicating the current state (e.g. new, superseded or accepted etc.) of the associated request. A state change of the request will be
@@ -31,7 +31,7 @@ filter selectors, giving you a hint at first glance, which kind of notifications
 
 <img src="/images/posts/sprint-report-79/notification_filter_counter.png" alt="Notification filter counter"/>
 
-Marking a notification as read won't cause full page reload's from now on. We only refresh the parts that needs
+Marking a notification as read won't cause full page reload from now on. We only refresh the parts that need
 to be refreshed. This saves unnecessary loading times and leads to a better overall experience while scrolling
 through the items.
 


### PR DESCRIPTION
Nothing major, just minor possible improvements I've found our last blog post.