### PR TITLE
Remove mentions of openFATE on support page

### DIFF
--- a/support/index.html
+++ b/support/index.html
@@ -32,9 +32,7 @@ title: Support
     <h3>we better ourselves</h3>
     <p>
     Sometimes it's not really a defect that is bugging you but missing functionality. You have an idea how to make OBS better, faster,
-    stronger. Those ideas we call <b>feature</b> and we track them in <a href="https://features.opensuse.org/feature/new" target="_blank">openFATE</a>,
-    the feature- and requirements management system of the openSUSE community. How to use openFATE is
-    <a href="https://en.opensuse.org/openSUSE:Openfate_documentation" target="_blank">documented in their wiki</a>
+    stronger. Those ideas we call <b>feature</b> and we track them on <a href="https://github.com/openSUSE/open-build-service/issues" target="_blank">GitHub</a>.
     </p>
 
     <h2>Commercial Support Offerings...</h2>


### PR DESCRIPTION
openFATE has been discontinued and should no longer be linked to as there is no archive.

This fixes #237.