### PR TITLE
Fix capitalization in "Introduction Flatpak Builds" blog post

### DIFF
--- a/_posts/development/2021-02-18-introducing-flatpak-builds.md
+++ b/_posts/development/2021-02-18-introducing-flatpak-builds.md
@@ -81,7 +81,7 @@ runtime-version: '3.36'
 # etc.
 ~~~
 
-## How does the build work?
+## How Does the Build Work?
 
 OBS is not a replacement for Flathub, so we had to find a solution for
 providing the basic dependencies.


### PR DESCRIPTION
Just something I've noticed while reading the blog post.