### PR TITLE
Point to the IRC channel on the Libera.Chat network

### DIFF
--- a/_includes/partials/_how-to-give-us-feedback.md
+++ b/_includes/partials/_how-to-give-us-feedback.md
@@ -7,7 +7,7 @@ There are two ways to reach us:
   and / or [commenting on an already opened
   issue](https://github.com/openSUSE/open-build-service/issues).
 - On IRC, by talking directly to us. We are in the channel
-  `#opensuse-buildservice` on *Freenode*.
+  `#opensuse-buildservice` on *Libera.Chat*.
 
 Please note that we favor GitHub to gather feedback as it allows us to easily
 keep track of the discussions.

--- a/_includes/partials/_revamping-ui-what-is-coming-next.md
+++ b/_includes/partials/_revamping-ui-what-is-coming-next.md
@@ -2,4 +2,4 @@
 
 We will be working next on the {{ include.pages }} pages. Stay tuned, we will inform you as soon as it is available in the beta program.
 
-We are looking forward to hearing from you on [GitHub](https://github.com/openSUSE/open-build-service/issues/new/choose) and in the `#opensuse-buildservice` IRC channel on *Freenode*!
+We are looking forward to hearing from you on [GitHub](https://github.com/openSUSE/open-build-service/issues/new/choose) and in the `#opensuse-buildservice` IRC channel on *Libera.Chat*!

--- a/_includes/partials/_team_gallery.html
+++ b/_includes/partials/_team_gallery.html
@@ -36,7 +36,7 @@
         <a href="{{ team_member.blog }}" target="_blank" title="{{ short_name }}'s Blog"><i class="big rss icon"></i></a>
         {% endif %}
         {% if team_member.irc %}
-        <i class="big comments outline icon link" title="{{ team_member.irc }} at IRC (Freenode)" data-content="{{ team_member.irc }} at IRC (Freenode)"></i>
+        <i class="big comments outline icon link" title="{{ team_member.irc }} at IRC (Libera.Chat)" data-content="{{ team_member.irc }} at IRC (Libera.Chat)"></i>
         {% endif %}
       </div>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -87,7 +87,7 @@
         <div class="three wide column">
           <div class="ui inverted link list">
             <h4 class="ui inverted header">Contact</h4>
-            <a href="irc://irc.freenode.net/openSUSE-buildservice" rel="nofollow" target="_blank" title="#openSUSE-buildservice IRC" class="item"><i class="comments outline icon"></i> IRC chat</a>
+            <a href="irc://irc.libera.chat/openSUSE-buildservice" rel="nofollow" target="_blank" title="#openSUSE-buildservice IRC" class="item"><i class="comments outline icon"></i> IRC chat</a>
             <a href="https://lists.opensuse.org/archives/list/buildservice@lists.opensuse.org/" target="_blank" title="OBS Mailing list" class="item"><i class="mail icon"></i> Mailing list</a>
             <a href="https://twitter.com/obshq" target="_blank" title="OBS on Twitter" class="item"><i class="twitter icon"></i> Twitter</a>
           </div>

--- a/_posts/development/2018-10-05-revamping-ui.md
+++ b/_posts/development/2018-10-05-revamping-ui.md
@@ -38,7 +38,7 @@ There are two ways to reach us:
   and / or [commenting on an already opened
   issue](https://github.com/openSUSE/open-build-service/issues).
 - On IRC, by talking directly to us. We are in the channel
-  `#opensuse-buildservice` on *Freenode*.
+  `#opensuse-buildservice` on *Libera.Chat*.
 
 Please note that we favor GitHub to gather feedback as it allows us to easily
 keep track of the discussions.

--- a/_posts/development/2019-08-12-address-typography-issues.md
+++ b/_posts/development/2019-08-12-address-typography-issues.md
@@ -60,7 +60,7 @@ There are two ways to reach us:
 
 - On GitHub, by [opening an issue](https://github.com/openSUSE/open-build-service/issues/new/choose)
   and / or [commenting on an already opened issue](https://github.com/openSUSE/open-build-service/issues).
-- On IRC, by talking directly to us. We are in the channel `#opensuse-buildservice` on *Freenode*.
+- On IRC, by talking directly to us. We are in the channel `#opensuse-buildservice` on *Libera.Chat*.
 
 Please note that we favor GitHub to gather feedback as it allows us to easily
 keep track of the discussions.

--- a/_posts/development/2019-08-27-address-typography-issues-part-02.md
+++ b/_posts/development/2019-08-27-address-typography-issues-part-02.md
@@ -88,6 +88,6 @@ There are two ways to reach us:
 
 - On GitHub, by [opening an issue](https://github.com/openSUSE/open-build-service/issues/new/choose)
   and / or [commenting on an already opened issue](https://github.com/openSUSE/open-build-service/issues).
-- On IRC, by talking directly to us. We are in the channel `#opensuse-buildservice` on *Freenode*.
+- On IRC, by talking directly to us. We are in the channel `#opensuse-buildservice` on *Libera.Chat*.
 
 Please note that we favor GitHub to gather feedback as it allows us to easily keep track of the discussions.

--- a/_posts/development/2020-02-17-mobile-first-layout.md
+++ b/_posts/development/2020-02-17-mobile-first-layout.md
@@ -78,6 +78,6 @@ Try the new features and tell us what you think about it.
 There are two ways to reach us:
 
 - On GitHub, by opening an issue and / or commenting on an already opened issue.
-- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Freenode.
+- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Libera.Chat.
 
 Please note that we favor GitHub to gather feedback as it allows us to easily keep track of the discussions.

--- a/_posts/development/2020-03-03-who-said-obs-was-unusable.md
+++ b/_posts/development/2020-03-03-who-said-obs-was-unusable.md
@@ -85,6 +85,6 @@ And if you haven't done it already, please join [the beta program](https://openb
 
 There are two ways to reach us:
 - On GitHub, by opening an issue and / or commenting on an already opened issue.
-- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Freenode.
+- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Libera.Chat.
 
 Please note that we favor GitHub to gather feedback as it allows us to easily keep track of the discussions.

--- a/_posts/development/2020-03-24-notifications-redesign.md
+++ b/_posts/development/2020-03-24-notifications-redesign.md
@@ -78,6 +78,6 @@ If you haven't done it already, please join [the beta program](https://openbuild
 
 There are two ways to reach us:
 - On GitHub, by opening an issue and / or commenting on an already opened issue.
-- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Freenode.
+- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Libera.Chat.
 
 Please note that we favor GitHub to gather feedback as it allows us to easily keep track of the discussions.

--- a/_posts/development/2020-04-06-rails6.md
+++ b/_posts/development/2020-04-06-rails6.md
@@ -52,6 +52,6 @@ We hope you also find them useful and they inspire you to start [contributing to
 Do you have any question or suggestion? Have you noticed any malfunction in OBS? Get in touch with us:
 
 - On GitHub, by opening an issue and / or commenting on an already opened issue.
-- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Freenode.
+- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Libera.Chat.
 
 We are looking forward to reading from you and crossing more tasks off the list.  :heavy_check_mark:

--- a/_posts/development/2020-04-27-notifications-round-two.md
+++ b/_posts/development/2020-04-27-notifications-round-two.md
@@ -85,6 +85,6 @@ If you haven't done it already, please join [the beta program](https://openbuild
 
 There are two ways to reach us:
 - On GitHub, by opening an issue and / or commenting on an already opened issue.
-- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Freenode.
+- On IRC, by talking directly to us. We are in the channel #opensuse-buildservice on Libera.Chat.
 
 Please note that we favor GitHub to gather feedback as it allows us to easily keep track of the discussions.

--- a/_posts/project/2019-05-14-build-solutions-team.md
+++ b/_posts/project/2019-05-14-build-solutions-team.md
@@ -169,7 +169,7 @@ People assigned to this card are responsible for deployments, tool maintenance,
 OBS:Server:Unstable maintenance, etc.
 
 ## Where Does the Team Meet?
-The Build Solutions team hangs out on the IRC channel #opensuse-buildservice on the Freenode network.
+The Build Solutions team hangs out on the IRC channel #opensuse-buildservice on the Libera.Chat network.
 They read and write to the [opensuse-buildservice@opensuse.org mailing list](https://lists.opensuse.org/opensuse-buildservice/).
 Additionally, as contributing is their full time job, they have some meetings where they talk to
 each other to coordinate their work. If you want to participate in any of those meetings, join

--- a/_posts/releases/2008-06-11-version-1.0-rc1.html
+++ b/_posts/releases/2008-06-11-version-1.0-rc1.html
@@ -48,6 +48,6 @@ The Open Build Service is now considered "feature complete" for collaboration, b
 is expecting a lot of user feedback since this now is openSUSE's standard tool for working on their
 distribution. We will be releasing frequent updates to improve the Build Service based on this feedback.
 Contributors can discuss the build service on the
-<a href="mailto:opensuse-buildservice+subscribe@opensuse.org">mailing list</a> and on Freenode in the
+<a href="mailto:opensuse-buildservice+subscribe@opensuse.org">mailing list</a> and on Libera.Chat in the
 <a href="irc://irc.opensuse.org/opensuse-buildservice">#opensuse-buildservice</a> channel.
 </p>

--- a/_posts/releases/2009-03-19-version-1.5.html
+++ b/_posts/releases/2009-03-19-version-1.5.html
@@ -61,5 +61,5 @@ have early access to these features
 The OBS team is always looking for additional feedback and contributors to improve the Open Build Service.
 To discuss Build Service development, subscribe to the opensuse-buildservice list
 (<a href="mailto:opensuse-buildservice+subscribe@opensuse.org">opensuse-buildservice+subscribe@opensuse.org</a>),
-and see the #opensuse-buildservice channel on Freenode.
+and see the #opensuse-buildservice channel on Libera.Chat.
 </p>


### PR DESCRIPTION
```
The opensuse-buildservice channel moved to the Libera.Chat network.
The capitalization of "Libera.Chat" is in line with the one used in
the open-build-service git repo.
```