### PR TITLE
Set site.url to fix broken links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: Open Build Service
+site: https://openbuildservice.org
 highlighter: rouge
 permalink: /:year/:month/:day/:title/
 markdown: kramdown


### PR DESCRIPTION
Brokens links were the "Share Twitter" button at the bottom of every blog post and links in the RSS feed. In Jekyll <4.2, the value of `site.url` defaults to `0.0.0.0:4000` when the website is generated in the development environment.

Before, the RSS feed with broken links which don't contain the domain:
```xml
      <entry>
          <title>A Bit of Action for Pull/Merge Requests and the Tokens UI</title>
          <link href="/2021/09/14/scm-more-pull-request-actions-and-ui//"/>
          <updated>2021-09-14T00:00:00+00:00</updated>
          <id>/2021/09/14/scm-more-pull-request-actions-and-ui//</id>
          <summary type="html">After a quiet vacation month in August, we’re back with changes to improve workflows in the integration between OBS and source code management systems (SCM) like GitHub and GitLab. Workflows are cleaning up after themselves when pull/merge requests are closed or merged. And additionally to that, you can now regenerate and trigger tokens in the web UI. If you haven’t already, join the beta program to start integrating OBS with SCMs. We started off the...</summary>
      </entry>
```

After, the RSS feed with working links (starting with `0.0.0.0:4000` when generated in development, otherwise starting with `https://openbuildservice.org` when generated in production):

```xml
      <entry>
          <title>A Bit of Action for Pull/Merge Requests and the Tokens UI</title>
          <link href="http://0.0.0.0:4000/2021/09/14/scm-more-pull-request-actions-and-ui//"/>
          <updated>2021-09-14T00:00:00-05:00</updated>
          <id>http://0.0.0.0:4000/2021/09/14/scm-more-pull-request-actions-and-ui//</id>
          <summary type="html">After some quiet vacation month, we’re back with changes to improve workflows in the integration between OBS and source code management systems (SCM) like GitHub and GitLab. Workflows are cleaning up after themselves when pull/merge requests are closed or merged. And additionally to that, you can now regenerate and trigger tokens in the web UI. If you haven’t already, join the beta program to start integrating OBS with SCMs. We started off the continuous integration...</summary>
      </entry>
```