### PR TITLE
Update index.html

### DIFF
--- a/download/other/index.html
+++ b/download/other/index.html
@@ -77,7 +77,7 @@ title: Download
       <div class="ui raised secondary segment">
         <h4 class="ui header">SUSE Linux Enterprise</h4>
         <p class="code">
-          zypper ar -f https://download.opensuse.org/repositories/OBS:/Server:/2.10/SLE_15_SP3/OBS:Server:2.10.repo
+          zypper ar -f https://download.opensuse.org/repositories/OBS:/Server:/2.10/15.3/OBS:Server:2.10.repo
         </p>
         <p class="code">
           zypper in -t pattern OBS_Server


### PR DESCRIPTION
Some time ago, we switched the name of the zypper repository for the SLE 15 SP3 from `SLE_15_SP3`, to `15.3`, and we forgot to update this documentation