### PR TITLE
Add open-build-service-documentation to 'git add' command in update_documentation.sh

### DIFF
--- a/update_documentation.sh
+++ b/update_documentation.sh
@@ -64,7 +64,7 @@ for doc in obs-admin-guide obs-user-guide; do
   popd
 
   # add to git 
-  git add help/manuals/$doc files/manuals/$doc.epub files/manuals/$doc.pdf || exit 1
+  git add open-build-service-documentation help/manuals/$doc files/manuals/$doc.epub files/manuals/$doc.pdf || exit 1
 done
 
 git commit -m "Update books to current state" || exit 1


### PR DESCRIPTION
This submodule is updated in update_documentation.sh, but the changes were never added to the commit.