### PR TITLE
Announce management of beta features

### DIFF
--- a/_posts/development/2022-03-17-beta-features-management.md
+++ b/_posts/development/2022-03-17-beta-features-management.md
@@ -1,0 +1,38 @@
+---
+layout: post
+title: Manage Your Beta Features
+category: development
+---
+
+Did you join the beta program, but somehow wish you could disable a specific
+beta feature? This is now possible with the new _Manage Beta Features_ page.
+
+# What Changed Exactly?
+
+Before, you joined the beta program and all beta features were enabled. If you
+somehow didn't want a certain beta feature, you couldn't disable it. You had
+to leave the beta program to disable all beta features. Now, you can manage
+which beta feature is enabled or disabled.
+
+# How Does It Work?
+
+By default, all beta features are enabled as soon as you join the beta program.
+To manage which beta feature is enabled or disabled, be sure to be logged in,
+then visit the [Manage Beta
+Features](https://build.opensuse.org/my/beta_features) page. There is a link to
+this page on your [profile](https://build.opensuse.org/home) under the _Actions
+on this page_ sidebar menu on desktop and the _Actions_ menu on mobile.
+
+On that page, you can join or leave the beta program by clicking on the _Beta
+program_ switch. Enabling or disabling is just the same, click on the switch of
+the beta feature you wish to enable or disable.
+
+# Stay Informed
+
+Whenever the beta program changes, we announce those changes just like we do
+here in this blog post. However, we have an entire blog post dedicated to the
+[beta program](/2018/10/04/the-beta-program), so be sure to read it if you
+haven't already. That blog post is the definite reference on the beta program.
+We keep it up-to-date.
+
+{% include partials/_how-to-give-us-feedback.md %}


### PR DESCRIPTION
This is the official blog post on the changes introduced to allow users to manage beta features. The blog post on the beta program, which is referred in all other blog posts, is updated in this other PR: https://github.com/openSUSE/obs-landing/pull/347