### PR TITLE
Add 2 latest blog posts in series of SCM/CI integration

### DIFF
--- a/_includes/partials/_series-of-posts-about-scm-integration.md
+++ b/_includes/partials/_series-of-posts-about-scm-integration.md
@@ -7,6 +7,8 @@ In September 2021, we [supported more actions for pull/merge requests, improved 
 and [added support for push events and a rebuild step](/2021/09/28/support-for-push-events). In November 2021, we presented the
 [user documentation and further improvements for the UI for tokens](/2021/11/09/scm-integration-documentation) and [workflow runs and more](/2021/11/22/scm-workflow-runs).
 We worked on [UI and reporting improvements](/2022/02/03/scm-integration-report-improvements) in February 2022, followed by a
-[step to trigger services](/2022/04/04/scm-integration-trigger_services) and [the improvement of the error messages](/2022/04/20/scm-integration-better-error-messages) in April 2022._
+[step to trigger services](/2022/04/04/scm-integration-trigger_services) and [the improvement of the error messages](/2022/04/20/scm-integration-better-error-messages) in April 2022.
+Afterwards, we clarified the [separation between incoming webhooks and status reports](/2022/05/31/seperation-of-webhook-and-status-reports) in May 2022, then [sharing tokens](/2022/06/20/token-sharing)
+was made possible in June 2022._
 
 _This feature is documented in the [SCM/CI Workflow Integration chapter](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html) of the [OBS User Guide](https://openbuildservice.org/help/manuals/obs-user-guide/)._

--- a/_posts/development/2022-06-20-token-sharing.md
+++ b/_posts/development/2022-06-20-token-sharing.md
@@ -6,6 +6,8 @@ category: development
 
 With the introduction of the workflows, a wide range of integrations became available for individual users. Now those integrations start to get interesting at team level too. But, until now, you could not use the same workflow token with a group of users. We've fixed that for you. 
 
+{% include partials/_series-of-posts-about-scm-integration.md %}
+
 # One Token To Rule Them All
 
 Let's say a group of maintainers automated the rebuild of packages when new commits are pushed into their associated GitLab repositories. To do that, those users needed a Workflow Token, and that token is bound to a single user. The only way to trigger the workflow by more than one user was to share the user credentials.


### PR DESCRIPTION
The missing `include` was also added to the latest blog post `Token Party!`.

Preview of the changes (highlighted in red):
![change](https://user-images.githubusercontent.com/1102934/178490550-5b90c2fb-43fa-419d-b8c9-5b2f3e1e3694.png)