### PR TITLE
Change the links to the new apidocs url

### DIFF
--- a/_posts/development/2021-01-26-api-documentation-remake.md
+++ b/_posts/development/2021-01-26-api-documentation-remake.md
@@ -19,10 +19,10 @@ In the last days we documented, using OpenAPI, a list of endpoints, which will g
   <figcaption>OBS API New Documentation Page</figcaption>
 </figure>
 
-This documentation page is now available [here](https://build.opensuse.org/apidocs-new/).
+This documentation page is now available [here](https://api.opensuse.org/apidocs/).
 
 Something to notice, is that the new documentation is not defining schemas to be used for XML validations, both for requests and responses.
-It will refer to the existing XML validation schemas, also found in the still usable [API documentation](https://build.opensuse.org/apidocs/).
+It will refer to the existing XML validation schemas, also found in the still usable [API documentation](https://build.opensuse.org/apidocs-old/).
 
 [OpenAPI specification](https://www.openapis.org/) is "a specification for machine-readable interface files for describing,
 producing, consuming, and visualizing RESTful web services" (according to [Wikipedia](https://en.wikipedia.org/wiki/OpenAPI_Specification)).

--- a/_posts/development/2021-04-12-api-docs-workers-and-build.md
+++ b/_posts/development/2021-04-12-api-docs-workers-and-build.md
@@ -13,7 +13,7 @@ In the last days we documented Build and Workers related endpoints. Stay tuned, 
   <figcaption>OBS API New Documentation Page</figcaption>
 </figure>
 
-This documentation page is now available [here](https://build.opensuse.org/apidocs-new/).
+This documentation page is now available [here](https://api.opensuse.org/apidocs/).
 
 We still have a lot to do in this area. However, after every sprint where we review the actual documentation, dig into code, play around with the API, and migrate the documentation to the OpenAPI standard, we don't just come up with a better looking documentation, but we learn more about our API itself too.
 

--- a/_posts/development/2021-10-12-notifications-group-filter.md
+++ b/_posts/development/2021-10-12-notifications-group-filter.md
@@ -32,6 +32,6 @@ Last but not least, we introduced a new API to help you as a power user in readi
 ```
 osc api '/my/notifications?project=home:Admin'
 ```
-You can find the API documentation [here](https://build.opensuse.org/apidocs-new)
+You can find the API documentation [here](https://api.opensuse.org/apidocs/)
 
 {% include partials/_how-to-give-us-feedback.md %}

--- a/_posts/development/2021-12-09-api-docs-sources-and-search.md
+++ b/_posts/development/2021-12-09-api-docs-sources-and-search.md
@@ -11,8 +11,8 @@ This time we documented the project sources and some of the search endpoints.
 
 If you are curious, just check them out!
 
-* [Sources - Project](https://build.opensuse.org/apidocs-new/#/Sources%20-%20Projects)
-* [Search](https://build.opensuse.org/apidocs-new/#/Search)
+* [Sources - Project](https://api.opensuse.org/apidocs/#/Sources%20-%20Projects)
+* [Search](https://api.opensuse.org/apidocs/#/Search)
 
 As always, feedback is really welcome :)
 

--- a/_posts/development/2022-08-29-api-docs-search.md
+++ b/_posts/development/2022-08-29-api-docs-search.md
@@ -11,7 +11,7 @@ This time we fully documented the search endpoints.
 
 Please just check them out!
 
-* [Search](https://build.opensuse.org/apidocs-new/#/Search)
+* [Search](https://api.opensuse.org/apidocs/#/Search)
 
 As always, we will appreciate your feedback!
 

--- a/_posts/documentation/2022-10-10-more-api-docs-sources.md
+++ b/_posts/documentation/2022-10-10-more-api-docs-sources.md
@@ -4,14 +4,14 @@ title: More API Endpoint Documentation for Project and Package Sources
 category: development
 ---
 
-Remember our [new openAPI Documentation](https://build.opensuse.org/apidocs-new/)? Of course you do! 
+Remember our [new openAPI Documentation](https://api.opensuse.org/apidocs/)? Of course you do! 
 
 And we also did! That's why we added some more documentation about project and package endpoints.
 
 You can check them out below!
 
-* [Sources - Projects](https://build.opensuse.org/apidocs-new/#/Sources%20-%20Projects)
-* [Sources - Packages](https://build.opensuse.org/apidocs-new/#/Sources%20-%20Packages)
+* [Sources - Projects](https://api.opensuse.org/apidocs/#/Sources%20-%20Projects)
+* [Sources - Packages](https://api.opensuse.org/apidocs/#/Sources%20-%20Packages)
 
 {% include partials/_series-of-posts-about-api-docs.md %}
 

--- a/_posts/documentation/2023-03-21-continuing-api-docs-sources.md
+++ b/_posts/documentation/2023-03-21-continuing-api-docs-sources.md
@@ -4,13 +4,13 @@ title: Continuing on API Endpoint Documentation for Package and File Sources
 category: development
 ---
 
-You might have been already using our [new openAPI Documentation](https://build.opensuse.org/apidocs-new/).
+You might have been already using our [new openAPI Documentation](https://api.opensuse.org/apidocs/).
 We now want to let you know we added some more documentation about package endpoints and we added the new section about file endpoints.
 
 You can check them out below!
 
-* [Sources - Packages](https://build.opensuse.org/apidocs-new/#/Sources%20-%20Packages)
-* [Sources - Files](https://build.opensuse.org/apidocs-new/#/Sources%20-%20Files)
+* [Sources - Packages](https://api.opensuse.org/apidocs/#/Sources%20-%20Packages)
+* [Sources - Files](https://api.opensuse.org/apidocs/#/Sources%20-%20Files)
 
 {% include partials/_series-of-posts-about-api-docs.md %}
 

--- a/_posts/documentation/2023-05-02-api-docs-comments-status-staging.md
+++ b/_posts/documentation/2023-05-02-api-docs-comments-status-staging.md
@@ -4,14 +4,14 @@ title: Newly Documented API Endpoints for Comments, Status Messages and Staging
 category: development
 ---
 
-You hopefully have seen our [new openAPI Documentation](https://api.opensuse.org/apidocs-new/).
+You hopefully have seen our [new openAPI Documentation](https://api.opensuse.org/apidocs/).
 You might have, since it's now linked from the old documentation. Besides that change, we spent some of our development time on new documentation on Comments, Status Messages and Staging Workflows.
 
 Please check them out below!
 
-* [Comments](https://api.opensuse.org/apidocs-new/#/Comments)
-* [Status Messages](https://api.opensuse.org/apidocs-new/#/Status%20Messages)
-* [Staging Workflows](https://api.opensuse.org/apidocs-new/#/Staging%20Workflow)
+* [Comments](https://api.opensuse.org/apidocs/#/Comments)
+* [Status Messages](https://api.opensuse.org/apidocs/#/Status%20Messages)
+* [Staging Workflows](https://api.opensuse.org/apidocs/#/Staging%20Workflow)
 
 {% include partials/_series-of-posts-about-api-docs.md %}
 


### PR DESCRIPTION
This integrates changes from https://github.com/openSUSE/obs-docu/pull/286, and changes the remaining links on the page to the new apidocs urls. I also included fixes to the script for updating documentation