### PR TITLE
Small typo updates to the Security Concepts page

### DIFF
--- a/help/manuals/obs-admin-guide/obs.cha.security_concepts.html
+++ b/help/manuals/obs-admin-guide/obs.cha.security_concepts.html
@@ -114,19 +114,19 @@ hljs.configure({
    </p><p>A SSL certificate is derived from the keys when needed (for example, for secure boot).
    </p><p>GPG keypairs are created by the <code class="systemitem">signd</code> daemon. Therefore,
          it is recommend to run this daemon on a separated and protected host. The
-         master key pair should exist only on this signd host. Any further
-         created keypair is not stored on the signd instance, instead
+         master keypair should exist only on this <code class="systemitem">signd</code> host. Any further
+         created keypair is not stored on the <code class="systemitem">signd</code> instance, instead
          the private part is encrypted with the master key and transferred
          to the Open Build Service backend. Thus, the <code class="systemitem">signd</code> instance is stateless and
          needs no recurring backups after initial setup.
          All keypairs (public and private parts) are therefore part of the
-         backup of the Open Build Service backend servers. The sign executable is
-         transferring just the hash to be signed (not the entire file content) together
-         with the crypted private key to <code class="systemitem">signd</code>. The daemon
+         backup of the Open Build Service backend servers. The <code class="systemitem">sign</code> executable
+         transfers just the hash to be signed (not the entire file content) together
+         with the encrypted private key to <code class="systemitem">signd</code>. The daemon
          decrypts the private key with the master key, creates the signature, and sends it
-         back to the client. The returned signature is applied to the binary by the sign
+         back to the client. The returned signature is applied to the binary by the <code class="systemitem">sign</code>
          executable afterwards.
-   </p><p>A compromised backend is still be a serious security incident
+   </p><p>A compromised backend would still result in a serious security incident
          since any content can be signed with any project key. The private
          keys are not compromised themselves though.
    </p></div></div><div class="sect1 " id="trust_zones"><div class="titlepage"><div><div><h2 class="title"><span class="number">3.2 </span><span xmlns:dm="urn:x-suse:ns:docmanager" class="name">Trust Zones </span> <a title="Permalink" class="permalink" href="obs.cha.security_concepts.html#trust_zones">#</a></h2></div></div></div><p>Open Build Service (OBS) components deal with different trust zones. These are


### PR DESCRIPTION
Proposing some small typo updates to the "Signature Handling" section.