### PR TITLE
Fix OpenGraph URL metadata (og:url)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
   <!-- OpenGraph metadata -->
   {%- assign page_title = page.title | default: site.title | escape %}
   {%- assign page_description = page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape %}
-  {%- assign page_url = page.path | replace:'index.html','' | absolute_url %}
+  {%- assign page_url = page.url | replace:'index.html','' | absolute_url %}
   {%- assign page_image = page.image | default: '/images/obs-banner.png' | absolute_url %}
   <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:title" content="{{ page_title }}">


### PR DESCRIPTION
Closes: #442

When we paste a link to our blog post on social media, its appearance is determined by the OpenGraph metadata we set on our HTML (PR #395).

One of the OpenGraph tags we can set is `og:url` (the URL of the content).

![social_media_og_url](https://github.com/openSUSE/obs-landing/assets/2581944/6ce12bbc-2433-4596-bf2f-1aafdd01c56f)

So far the value has been incorrect. Having URLs like
```
https://openbuildservice.org/_posts/development/2023-11-30-whatnot.md
```
where we should have
```
https://openbuildservice.org/2023/11/30/whatnot/
```

Jekyll provides the `page`  Liquid variable with both `page.path` and `page.url` properties. `page.url` is the one we need. Read the differences [here](https://jekyllrb.com/docs/variables/#page-variables). 

## Testing Tips

Check the page source of the deploy preview or on localhost:4000 and search for `og:url`, it should contain the correct URL now.