### PR TITLE
Bump nokogiri to 1.18.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     mercenary (0.4.0)
     mini_portile2 (2.8.5)
     minitest (5.19.0)
-    nokogiri (1.15.6)
+    nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     pathutil (0.16.2)


### PR DESCRIPTION
Depends on https://github.com/openSUSE/obs-landing/pull/493 because updating nokogiri >= 1.18 requires ruby >= 3.1.0

---
## Nokogiri v1.18.8 upgrades its dependency libxslt and fixes the following:


https://github.com/openSUSE/obs-landing/security/dependabot/29

libxml2 v2.12.7 addresses https://github.com/advisories/GHSA-vv62-jfwq-693v:

    described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/720
    patched by https://gitlab.gnome.org/GNOME/libxml2/-/commit/2876ac53

---

https://github.com/openSUSE/obs-landing/security/dependabot/38

libxml2 v2.13.6 addresses:

    https://github.com/advisories/GHSA-fgfv-9xqc-v794
        described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/847
    https://github.com/advisories/GHSA-m366-8h8r-6fqr
        described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/828
---

https://github.com/openSUSE/obs-landing/security/dependabot/40

libxslt v1.1.43 resolves:

- CVE-2025-24855: Fix use-after-free of XPath context node
- CVE-2024-55549: Fix UAF related to excluded namespaces

---

https://github.com/openSUSE/obs-landing/security/dependabot/41

libxml2 v2.13.8 addresses:

    https://github.com/advisories/GHSA-mfrm-w63c-3x58
        described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/889
    https://github.com/advisories/GHSA-w8fw-fj9q-vcjj
        described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/890