### PR TITLE
Add a share on mastodon button

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -24,6 +24,10 @@ layout: secondary
           <i class="twitter icon"></i>
           Share on Twitter
         </a>
+        <a href="https://share.joinmastodon.org/?text={{ page.title | url_encode }}%20{{ site.url }}{{ page.url | url_encode }}" rel="nofollow" target="_blank" title="Share on Mastodon" class="ui button">
+          <i class="mastodon icon"></i>
+          Share on Mastodon
+        </a>
       </div>
       <div class="ui grid">
         <div class="eight wide column">


### PR DESCRIPTION
I used https://share.joinmastodon.org/ so the user can select which Mastodon server share the snippet from.

Fixes #540