### PR TITLE
Drop twitter share icon

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,12 +20,8 @@ layout: secondary
         {{ content }}
       </div>
       <div class="share-icon">
-        <a href="https://twitter.com/intent/tweet?text={{ page.title }}&url={{ site.url }}{{ page.url }}&via=obshq&related=obshq" rel="nofollow" target="_blank" title="Share on Twitter" class="ui twitter button">
-          <i class="twitter icon"></i>
-          Share on Twitter
-        </a>
         <a href="https://share.joinmastodon.org/?text={{ page.title | url_encode }}%20{{ site.url }}{{ page.url | url_encode }}" rel="nofollow" target="_blank" title="Share on Mastodon" class="ui button">
-          <i class="mastodon icon"></i>
+          <i class="share icon"></i>
           Share on Mastodon
         </a>
       </div>


### PR DESCRIPTION
Also fixes mastodon icon...

## Before

<img width="919" height="277" alt="image" src="https://github.com/user-attachments/assets/82e8055b-91ed-489c-9471-cf3fe4acec88" />


## After

<img width="919" height="277" alt="Screenshot From 2026-05-04 17-43-17" src="https://github.com/user-attachments/assets/7a66bab7-6b1b-4465-8c62-e7227280a4ca" />
