### PR TITLE
Mention default appliance credentials on /download

### DIFF
--- a/_includes/appliance_config.inc
+++ b/_includes/appliance_config.inc
@@ -8,6 +8,10 @@
   on the harddisk you deploy the image to will get overwritten.
 </p>
 <p>
+  The default appliance credentials are <code>root</code> / <code>opensuse</code>. To log in to your local OBS instance,
+  use <code>Admin</code> / <code>opensuse</code>.
+</p>
+<p>
   All appliances come pre-configured with the right set of repositories and can be updated via the system tools YaST or zypper at any time.
   Another way is to replace the entire image. If you update the image, keep in mind that you need to have your data directory on a
   separate storage, otherwise it will get deleted.


### PR DESCRIPTION
## Description:

Issue #262 reported that the `/download` page did not mention the default appliance credentials for either the system root account or the local OBS admin account.

This PR updates the appliance configuration copy on the download page to include both default credentials: `root / opensuse` for the system login and `Admin / opensuse` for the local OBS instance.

Closes #262.

## Checklist:

- [x] I have verified on latest `master` that the credentials were missing before this change.
- [x] I have built the site in WSL using `docker run --name obs-landing-build262 -v /mnt/c/Users/Xeron/Desktop/FOSS/obs-landing-fix262:/srv/jekyll -w /srv/jekyll jekyll/jekyll:4 sh -lc "bundle install && bundle exec jekyll build --future"`.
- [x] I have verified the generated `/download` page locally.
