### PR TITLE
Fix inconsistent heading sizes in blog posts

### DIFF
--- a/stylesheets/app.css
+++ b/stylesheets/app.css
@@ -36,6 +36,10 @@
   padding: 8em 0em;
 }
 
+.ui.vertical.stripe h1 {
+  font-size: 3em;
+}
+
 .ui.vertical.stripe h2 {
   font-size: 2.5em;
 }


### PR DESCRIPTION
## Description:

Issue #170 reported that heading sizes in blog posts were inconsistent, with `h2` rendering larger than `h1`.

This PR adds the missing `h1` font size rule for `.ui.vertical.stripe`, keeping the heading scale consistent in blog posts and other stripe sections.

Closes #170.

## Checklist:

- [x] I have reproduced on latest `master` that a rendered blog post showed `h2` larger than `h1`.
- [x] I have built the site in my WSL based environment and verified the rendered page in a browser.
- [x] I have verified that the rendered heading scale is `h1 > h2 > h3 > h4` in the affected stripe layout.

### Before the fix:

<img width="694" height="428" alt="image" src="https://github.com/user-attachments/assets/8e2a9bcb-45d9-43d5-b551-8ca7d20db02c" />

### After the fix:

<img width="701" height="434" alt="image" src="https://github.com/user-attachments/assets/08e15952-8cc2-4075-880c-17d4c75689f7" />
