### PR TITLE
Fix volume permissions under SELinux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       JEKYLL_UID: 1000
       JEKYLL_GID: 100
     volumes:
-      - .:/srv/jekyll
+      - .:/srv/jekyll:Z


### PR DESCRIPTION
When launching the jekyll service inside docker under SELinux, the volume mountings are not available for regular users, we need to add specific suffixes to the volume definitions so SELinux allow mount them with proper permissions for regular users.

**To test this:**
1. go to master
2. run docker compose up
3. See permission errors on the console when the docker is trying to start jekyll
4. using this branch will fix those errors and the jekyll container boots perfectly