### PR TITLE
Fix foster collaboration series block links

### DIFF
--- a/_includes/partials/_series-of-posts-about-foster-collaboration.md
+++ b/_includes/partials/_series-of-posts-about-foster-collaboration.md
@@ -2,8 +2,8 @@ Our efforts to foster collaboration started in August 2024, when we [introduced 
 Next, we [improved labels to foster collaboration](/2024/09/25/improving-labels), allowed  [labeling projects](/2025/01/21/project-labels) and introduced the
 functionality of [managing labels with the API](/2025/05/05/labels-api). Building on that, we [introduced Assignments](/2025/05/15/foster-collaboration).
 Afterwards, we’ve introduced package version tracking based on the [Release Monitoring](/2025/09/23/foster-collaboration) which has been enhanced with
-the [Package Version Information](/2025/10/23/foster-collaboration). Then came [label-based filtering and automatic unassignments](2025-11-19-labels_and_assigments)
-when a request is accepted. Following that, [Package Version Tracking gained new capabilities](2026-02-20-version-tracking-improvements) like upstream release notifications
-and user documentation. We then introduced [New Version Tracking through API and Automatic Labeling](2026-03-03-foster-collaboration), followed by a
-[Quick Update on the Package Version Tracking Feature in OBS](2026-04-02-package-version-tracking-updates).
-This time we focused on [Quick Filtering by Label](2026-05-15-label-filtering) for projects, requests and notifications.
+the [Package Version Information](/2025/10/23/foster-collaboration). Then came [label-based filtering and automatic unassignments](/2025/11/19/labels_and_assigments)
+when a request is accepted. Following that, [Package Version Tracking gained new capabilities](/2026/02/20/version-tracking-improvements) like upstream release notifications
+and user documentation. We then introduced [New Version Tracking through API and Automatic Labeling](/2026/03/05/foster-collaboration), followed by a
+[Quick Update on the Package Version Tracking Feature in OBS](/2026/04/02/package-version-tracking-updates).
+This time we focused on [Quick Filtering by Label](/2026/05/15/label-filtering) for projects, requests and notifications.


### PR DESCRIPTION
## Description:

Issue #569 reported that the shared foster collaboration series block used relative links for several posts, so they resolved under the current post URL and returned `404`. One link also pointed to the wrong date path.

This PR updates the shared foster collaboration series partial to use the correct root relative post URLs and fixes the incorrect date path. Because the links live in a shared partial, the fix applies to all posts that render that series block.

Closes #569.

## Checklist:

- [x] I kept the fix minimal and limited to the shared foster collaboration series partial.
- [x] I built the site.
- [x] I ran `bundle exec jekyll doctor` .
- [x] I verified the rendered page locally in Chrome after the fix.