### PR TITLE
Tag links to openbuildservice.org with rel="canonical"

### DIFF
--- a/_includes/about.inc
+++ b/_includes/about.inc
@@ -4,7 +4,7 @@ in an automatic, consistent and reproducible way. You can release packages as we
 appliances and entire distributions for a wide range of operating systems and hardware architectures.
 </p>
 <p>
-It is developed by a talented <a href="https://openbuildservice.org/team/">team</a> of developers as
+It is developed by a talented <a href="https://openbuildservice.org/team/" rel="canonical">team</a> of developers as
 Free Software and is used by many Free and Open Source software projects, companies and researchers.
 Including but not limited to <a href="https://www.suse.com">SUSE</a> the original provider of the
 enterprise Linux distribution, the <a href="https://www.tizen.org/">Tizen</a> standards-based software

--- a/_includes/download.inc
+++ b/_includes/download.inc
@@ -1,5 +1,5 @@
 <p>
 You can download all the OBS components (Clients, API, Server, Worker) from our
-<a href="https://openbuildservice.org/download">download page</a> and setup your
+<a href="https://openbuildservice.org/download" rel="canonical">download page</a> and setup your
 own Open Build Service instance. 
 </p>

--- a/_plugins/canonical_links.rb
+++ b/_plugins/canonical_links.rb
@@ -1,0 +1,18 @@
+# Injects rel="canonical" onto every rendered <a> tag whose href points to
+# openbuildservice.org. This runs after Jekyll renders each page, post, and
+# document, so it covers links written in Markdown (which Kramdown renders as
+# plain <a> tags with no rel attribute) as well as any explicit HTML anchor
+# tags that were missed. Tags that already carry a rel attribute are left
+# unchanged to avoid duplicate or conflicting values.
+Jekyll::Hooks.register [:pages, :posts, :documents], :post_render do |doc|
+  doc.output = doc.output.gsub(
+    /<a\s([^>]*href=["'][^"']*openbuildservice\.org[^"']*["'][^>]*)>/i
+  ) do |match|
+    attrs = $1
+    if attrs.include?('rel=')
+      match
+    else
+      "<a #{attrs} rel=\"canonical\">"
+    end
+  end
+end

--- a/_posts/development/2017-05-05-frontend-sprint-report-1.html
+++ b/_posts/development/2017-05-05-frontend-sprint-report-1.html
@@ -61,7 +61,7 @@ excerpt_separator: <!--more-->
 <h3>Fix image branching from remote</h3>
 <p>
   When you branch a package from a project on another OBS instance over
-  <a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.concepts.html#idm140659249453056">interconnect</a>
+  <a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.concepts.html#idm140659249453056" rel="canonical">interconnect</a>
   the OBS would not pick up the repositories from the project you branch from.
   This only worked for branching from a local project. This was fixed in the
   <a href="https://github.com/openSUSE/open-build-service/pull/3000">pull request #3000</a>.

--- a/_posts/development/2017-05-19-frontend-sprint-report-2.html
+++ b/_posts/development/2017-05-19-frontend-sprint-report-2.html
@@ -113,8 +113,8 @@ category: development
   Last week we released the new <a href="https://build.opensuse.org/image_templates">image templates page</a>
   on the reference server. It was already included in the OBS 2.8 release, but not yet enabled. This sprint we enabled it
   and wrote two blog posts presenting that feature.
-  Here is the <a href="http://openbuildservice.org/2017/05/11/new-image-templates-page/">release announcement</a>.
-  And there is a second blog post describing how you can <a href="http://openbuildservice.org/2017/05/15/creating-your-own-image-template/">create your own image templates</a>.
+  Here is the <a href="http://openbuildservice.org/2017/05/11/new-image-templates-page/" rel="canonical">release announcement</a>.
+  And there is a second blog post describing how you can <a href="http://openbuildservice.org/2017/05/15/creating-your-own-image-template/" rel="canonical">create your own image templates</a>.
 </p>
 
 <h4>Researching Message Queues</h4>
@@ -137,7 +137,7 @@ category: development
 </p>
 <h4>Last Success for Multibuilds</h4>
 <p>
-  Some month ago we introduced the <a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.multibuild.html">multibuild</a>
+  Some month ago we introduced the <a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.multibuild.html" rel="canonical">multibuild</a>
   feature, which makes it possible to have multiple build descriptions in a package source and use so called flavors to filter them.
   Apparently we didn't integrate this into the build results API, which was reported by <a href="https://github.com/openSUSE/open-build-service/issues/3026">nilxam</a>.
   With <a href="https://github.com/openSUSE/open-build-service/pull/3106">pull request #3106</a> this has been fixed.

--- a/_posts/development/2017-06-12-sprint-report-3.md
+++ b/_posts/development/2017-06-12-sprint-report-3.md
@@ -24,7 +24,7 @@ category: development
 <h4>Blog about the STUDIO import/export feature</h4>
 <p>
   In case you have not heard about it. It's possible to import <a href="https://doc.opensuse.org/projects/kiwi/doc/">KIWI</a> configurations from <a href="https://susestudio.com/">SUSE Studio</a> to OBS. This sprint we
-<a href="http://openbuildservice.org/2017/05/31/studio-import/">released</a> a blog article that explains this feature in detail.
+<a href="http://openbuildservice.org/2017/05/31/studio-import/" rel="canonical">released</a> a blog article that explains this feature in detail.
 </p>
 
 <h4>Build Schedule Reason on WebUI</h4>

--- a/_posts/development/2017-07-10-sprint-report-5.md
+++ b/_posts/development/2017-07-10-sprint-report-5.md
@@ -38,7 +38,7 @@ category: development
     <img src="/images/posts/sprint_19_edit_kiwi_edit.png" style="margin: 30px 0 30px 0;" title='Kiwi editor – edit page' >
 
     And we also started to provide documentation for this feature in our Best Practice Guide, 
-    <a href="http://openbuildservice.org/help/manuals/obs-best-practices/cha.obs.best-practices.webuiusage.html#kiwi_editor_how_to">here</a>.
+    <a href="http://openbuildservice.org/help/manuals/obs-best-practices/cha.obs.best-practices.webuiusage.html#kiwi_editor_how_to" rel="canonical">here</a>.
 </p>
 
 <h4>Your OBS notifications as RSS feed</h4>

--- a/_posts/development/2017-07-24-sprint-report-6.md
+++ b/_posts/development/2017-07-24-sprint-report-6.md
@@ -49,7 +49,7 @@ Why is that so important?
  Not a very nice user experience.
 </p>
 <p>
- A few weeks ago we also released a <a href="http://openbuildservice.org/2017/07/04/post-mortem-1/">post mortem report</a> about a downtime caused by a wrong data migration.
+ A few weeks ago we also released a <a href="http://openbuildservice.org/2017/07/04/post-mortem-1/" rel="canonical">post mortem report</a> about a downtime caused by a wrong data migration.
  As we stated out in the post mortem, one reason this happened was that we didn't test this migration with production like data before.
  Therefore we invested some time in this sprint to <a href="https://github.com/openSUSE/open-build-service/pull/3401">develop a script</a> to import database dumps as easy as possible in development environment.
 </p>

--- a/_posts/development/2017-08-18-sprint-report-22.md
+++ b/_posts/development/2017-08-18-sprint-report-22.md
@@ -133,7 +133,7 @@ category: development
 <p>
    Some weeks ago we did one of our continuous deployments and ran into a problem. 
    An additional <a href='http://guides.rubyonrails.org/asset_pipeline.html#manifest-files-and-directives'>asset manifest file</a> broke our assets and we ended up with OBS pages without CSS. 
-   You might have seen us <a href='http://openbuildservice.org/2017/07/19/post-mortem-2/'>blogging</a> about it.
+   You might have seen us <a href='http://openbuildservice.org/2017/07/19/post-mortem-2/' rel="canonical">blogging</a> about it.
 </p>
 <p>
    What we also did was to create a <a href='https://trello.com/c/2HRVCSTJ/481-2-p8-ensure-public-assets-dir-of-our-packages-is-in-clean-state'>story</a> for one of our next sprints. 

--- a/_posts/development/2017-09-04-sprint-report-8.md
+++ b/_posts/development/2017-09-04-sprint-report-8.md
@@ -9,7 +9,7 @@ category: development
 
 <h2>OBS 2.8.3 Release</h2>
 
-<p>We have pushed out version 2.8.3. Check out the <a href='https://lists.opensuse.org/opensuse-buildservice/2017-08/msg00087.html'>announcement</a> about all the cool new things we rolled into our stable release and <a href='http://openbuildservice.org/download/'>download</a> it.</p>
+<p>We have pushed out version 2.8.3. Check out the <a href='https://lists.opensuse.org/opensuse-buildservice/2017-08/msg00087.html'>announcement</a> about all the cool new things we rolled into our stable release and <a href='http://openbuildservice.org/download/' rel="canonical">download</a> it.</p>
 
 <h2> Features </h2>
 

--- a/_posts/development/2017-10-09-sprint-report-10.md
+++ b/_posts/development/2017-10-09-sprint-report-10.md
@@ -22,14 +22,14 @@ Take a look into PR<a href="https://github.com/openSUSE/open-build-service/pull/
 Take a look into PR<a href="https://github.com/openSUSE/open-build-service/pull/3884">#3884</a>.
 </p>
 
-<p>The Kiwi Editor documentation was updated with all the new features until now and how to use it. <a href="http://openbuildservice.org/help/manuals/obs-best-practices/cha.obs.best-practices.webuiusage.html#kiwi_editor_how_to">See the documentation</a>.</p>
+<p>The Kiwi Editor documentation was updated with all the new features until now and how to use it. <a href="http://openbuildservice.org/help/manuals/obs-best-practices/cha.obs.best-practices.webuiusage.html#kiwi_editor_how_to" rel="canonical">See the documentation</a>.</p>
 
 <h3>RabbitMQ</h3>
 
 <p>
 It all started with Coolo <a href="https://github.com/openSUSE/open-build-service/pull/2592">requesting</a> a predecessor for the previously used hermes.
 OBS was using <a href="https://github.com/openSUSE/hermes">Hermes</a> to send out notifications. You might have read about it in our very first
-<a href="http://openbuildservice.org/2017/05/05/frontend-sprint-report-1/">Sprint Report</a>.
+<a href="http://openbuildservice.org/2017/05/05/frontend-sprint-report-1/" rel="canonical">Sprint Report</a>.
 </p>
 
 <p>
@@ -58,7 +58,7 @@ prefix of the queue name in the options.yml. Setting the 'amqp_namespace' to 'my
 </p>
 
 <p>
-There are many other options you can configure. All this is documented in our <a href="http://openbuildservice.org/help/manuals/obs-admin-guide/obs.cha.administration.html#_message_bus">admin guide</a>.
+There are many other options you can configure. All this is documented in our <a href="http://openbuildservice.org/help/manuals/obs-admin-guide/obs.cha.administration.html#_message_bus" rel="canonical">admin guide</a>.
 </p>
 
 <h3>Introduced bcrypt as password hash</h3>

--- a/_posts/documentation/2013-11-22-Source-Update-Via_Token.html
+++ b/_posts/documentation/2013-11-22-Source-Update-Via_Token.html
@@ -16,7 +16,7 @@ author: Adrian Schröter
 
     <p>
     Please find details about source services and authentification tokens in the 
-    <a href="http://openbuildservice.org/help/manuals/obs-reference-guide">OBS reference guide</a>.
+    <a href="http://openbuildservice.org/help/manuals/obs-reference-guide" rel="canonical">OBS reference guide</a>.
     Or learn about this example. You need also latest osc version 0.142 to use this.
     </p>
 

--- a/_posts/events/2012-10-17-obs-@-osc.md
+++ b/_posts/events/2012-10-17-obs-@-osc.md
@@ -99,5 +99,5 @@ all open source developers to build packages for the most popular distributions 
 Fedora, Ubuntu, Arch Linux, Red Hat Enterprise Linux and SUSE Linux Enterprise. It is also used to
 build the [openSUSE](http://www.opensuse.org) distribution.
   
-###Find out more, visit <a href="http://www.openbuildservice.org">www.openbuildservice.org</a>
+###Find out more, visit <a href="http://www.openbuildservice.org" rel="canonical">www.openbuildservice.org</a>
 

--- a/_posts/project/2011-05-26-opensuse-renames-obs.html
+++ b/_posts/project/2011-05-26-opensuse-renames-obs.html
@@ -73,7 +73,7 @@ cross-project goals and ambitions.
 The branding part of OBS will be adapted to make it easy for projects deploying their own OBS to name their OBS while
 staying connected with the OBS project. We suggest to name a project-specific OBS instance "XXX Open Build Service",
 like "VLC Open Build Service". The new domain name for the project will be 
-<a href="http://openbuildservice.org/">openbuildservice.org</a>.
+<a href="http://openbuildservice.org/" rel="canonical">openbuildservice.org</a>.
 </p>
 
 <h2>Reactions</h2>

--- a/_posts/releases/2012-09-10-arch-linux-support.html
+++ b/_posts/releases/2012-09-10-arch-linux-support.html
@@ -66,7 +66,7 @@ to your package sources and the OBS will build and publish a repository of <em>.
   <p>
     Of course the OBS is Free Software licensed under the GNU General Public License (GPL). It’s available
     for you as source, packages and as easily deployable appliance. You are free to use, fix, extend and re-use
-    the code. Check out our project <a href="http://www.openbuildservice.org/download">download page</a>.
+    the code. Check out our project <a href="http://www.openbuildservice.org/download" rel="canonical">download page</a>.
   </p>
   <p>
     Our reference server <a href="http://build.opensuse.org/">http://build.opensuse.org</a> is available for
@@ -75,4 +75,4 @@ to your package sources and the OBS will build and publish a repository of <em>.
     <a href="http://www.opensuse.org" title="openSUSE Linux">openSUSE</a> distribution.
   </p>
   
-<h2>Find out more, visit <a href="http://www.openbuildservice.org">www.openbuildservice.org</a></h2>
+<h2>Find out more, visit <a href="http://www.openbuildservice.org" rel="canonical">www.openbuildservice.org</a></h2>

--- a/_posts/releases/2013-04-30-version-2.4.html
+++ b/_posts/releases/2013-04-30-version-2.4.html
@@ -69,7 +69,7 @@ be used as a base for setting constraints.
 With this constraint system it is not only possible to better match build jobs to build environments but it also can
 be used to run, for instance, package benchmarks always on the same worker or distinguish between secure and insecure
 build environments. Documentation about this can be found in the
-<a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.build_job_constraints.html">
+<a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.build_job_constraints.html" rel="canonical">
 Open Build Service Reference Guide.</a>
 </p>
 
@@ -95,7 +95,7 @@ It is also recommended to read these before updating your instance.
 <p>
 
 <div style="float: left;">
-<a href="http://openbuildservice.org/download/">
+<a href="http://openbuildservice.org/download/" rel="canonical">
 <img src="/images/posts/obs-2.4-get.png" style="margin: 10px;">
 </a>
 </div>

--- a/_posts/releases/2014-03-31-version-2.5.html
+++ b/_posts/releases/2014-03-31-version-2.5.html
@@ -5,7 +5,7 @@ category: releases
 ---
 <p>
 Are you ready for another set of great features for your free software packaging needs?
-We are with version 2.5. of the <a href="http://openbuildservice.org" title="OBS Home Page">Open Build Service(OBS)</a>.
+We are with version 2.5. of the <a href="http://openbuildservice.org" title="OBS Home Page" rel="canonical">Open Build Service(OBS)</a>.
 With this release you can plug OBS into your continuous integration/delivery chain thanks to the new
 token API that let's you trigger builds from revision control systems like github.
 2.5 further merges the Web UI and API into one single Ruby on Rails app, so it is easier for
@@ -52,13 +52,13 @@ to be awesome! Read on for more, in depth, information about OBS version 2.5.
 <h6>Let github.com trigger your source update</h6>
 <p>
 OBS 2.5 provides an API to create authentication tokens to allow the execution of
-<a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.source_service.html">source services</a>.
+<a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.source_service.html" rel="canonical">source services</a>.
 That means you do not have to use your secret login credentials for
 this, which makes it easy to hook the OBS into aps like github.com for your
 continuous integration/delivery needs. Check out an example of this 2.5 feature
-<a href="http://openbuildservice.org/2013/11/22/Source-Update-Via_Token/">on our blog</a>
+<a href="http://openbuildservice.org/2013/11/22/Source-Update-Via_Token/" rel="canonical">on our blog</a>
 and make sure you read the chapter in our
-<a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.authorization.token.html#idm139695666033392">reference manual</a>
+<a href="http://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.authorization.token.html#idm139695666033392" rel="canonical">reference manual</a>
 on this topic.
 </p>
 
@@ -74,7 +74,7 @@ access to the API database and getting rid of the layer in between with all the 
 instantly! And as OBS admin you'll have one service less to maintain, monitor and support. Last
 but not least the new merged frontend also feels and behaves more like a standard
 Ruby on Rails app, which makes all OBS developers happier and more productive! Want to know more?
-Read about the merge <a href="http://openbuildservice.org/2013/10/28/webui-plus-api/">on our blog</a>!
+Read about the merge <a href="http://openbuildservice.org/2013/10/28/webui-plus-api/" rel="canonical">on our blog</a>!
 </p>
 
 
@@ -134,7 +134,7 @@ It is also recommended to read these before updating your OBS instance!
 <p>
 
 <div style="float: left;">
-<a href="http://openbuildservice.org/download/">
+<a href="http://openbuildservice.org/download/" rel="canonical">
 <img src="/images/posts/obs-2.4-get.png" style="margin: 10px;">
 </a>
 </div>

--- a/_posts/releases/2015-02-05-version-2.6.html
+++ b/_posts/releases/2015-02-05-version-2.6.html
@@ -89,7 +89,7 @@ It is also recommended to read these before updating your OBS instance!
 <p>
 
 <div style="float: left;">
-<a href="http://openbuildservice.org/download/">
+<a href="http://openbuildservice.org/download/" rel="canonical">
 <img src="/images/posts/obs-2.4-get.png" style="margin: 10px;">
 </a>
 </div>


### PR DESCRIPTION
Add a Jekyll post-render hook plugin that automatically injects rel="canonical" onto any rendered <a> tag pointing to openbuildservice.org, covering all Markdown links site-wide. Also manually add the attribute to explicit HTML anchor tags in includes and older post files.

Fixes #512