### PR TITLE
Fix broken email link in image template post

### DIFF
--- a/_posts/documentation/2017-05-15-creating-your-own-image-template.md
+++ b/_posts/documentation/2017-05-15-creating-your-own-image-template.md
@@ -55,5 +55,5 @@ You can do that by creating a Submit Request:
 
 <img src="/images/posts/image_templates_submit_request.png" style="margin:20px;" title="Image Template Submit Request">
 
-Or send an email to the [OBS admins](admin@opensuse.org) and request that your
+Or send an email to the [OBS admins](mailto:admin@opensuse.org) and request that your
 templates project is added to the templates page.


### PR DESCRIPTION
## Description:

The `Creating Your Own Image Template` post currently links `OBS admins` to `admin@opensuse.org` without a `mailto:` prefix.

This PR updates that post to use a proper mail link, so the rendered page no longer resolves the link as a broken relative URL.

## Checklist:

- [x] I built the site for verification in WSL using `bundle exec jekyll build`.
- [x] I ran `bundle exec jekyll doctor`.

### Before the fix:

<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/b37281b9-b818-4988-bac2-02ceb087125d" />

<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/1b6ecafc-1134-43d1-bc1c-8fb996d67f60" />

### After the fix:

<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/7c412255-fc6c-4fe6-a8fb-799580ec1b2d" />
