### PR TITLE
Fix stale SCM manual links in blog posts

### DIFF
--- a/_posts/development/2021-08-02-link-package-configure-repositories-and-ui.md
+++ b/_posts/development/2021-08-02-link-package-configure-repositories-and-ui.md
@@ -72,7 +72,7 @@ Inside the SCM configuration file, simply indicate which repositories you want f
 
 - Set up the integration between GitHub/GitLab and OBS. If you have not yet, please refer to this [blog post](/2021/05/31/scm-integration/).
 - Add the new step to `.obs/workflows.yml` as explained in the [user
-  documentation](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.configure_repositories_architectures_for_a_project).
+  documentation](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-configure-repositories-architectures-for-a-project).
 
 ## More to Come!
 

--- a/_posts/development/2021-11-22-scm-workflow-runs.md
+++ b/_posts/development/2021-11-22-scm-workflow-runs.md
@@ -60,7 +60,7 @@ Although this tool will be of great help to you, we recommend that you follow th
 
 Our workflows now accept push events for tags. You could, for example, run a certain workflow only when a tag is pushed to a repository rather than on every push to a branch.
 
-You can filter by this type of event as shown in the following example. Read more [here](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#id-1.5.8.5.2.8.10.8).
+You can filter by this type of event as shown in the following example. Read more [here](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-filters-event-filter).
 
 ```
 workflow:
@@ -75,7 +75,7 @@ workflow:
 
 For the branch package and link package steps, the package created by those steps will contain the name of the tag which triggered the webhook event.
 
-Refer to the [documentation about the steps](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.steps) for details on this.
+Refer to the [documentation about the steps](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-steps) for details on this.
 
 To ensure this is correctly working, you need to modify your webhook on GitLab to trigger _"Tag push events"_ if this isn't already done. For GitHub, you need nothing apart from _"Pushes"_.
 

--- a/_posts/development/2022-02-03-scm-integration-report-improvements.md
+++ b/_posts/development/2022-02-03-scm-integration-report-improvements.md
@@ -11,10 +11,10 @@ As you know, this is a beta feature. So, do not forget this feature is under [th
 {% include partials/_series-of-posts-about-scm-integration.md %}
 
 ## Support multiple repository paths for the configure_repositories step
-You already know about the `configure_repositories` step. Until now a single path element is defined per repository configured, but we realized for some projects more than one path has to be defined. So, we have made improvements for the support of multiple path elements. The breaking change has been documented and you can check it out [here](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.configure_repositories_architectures_for_a_project).
+You already know about the `configure_repositories` step. Until now a single path element is defined per repository configured, but we realized for some projects more than one path has to be defined. So, we have made improvements for the support of multiple path elements. The breaking change has been documented and you can check it out [here](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-configure-repositories-architectures-for-a-project).
 
 ## The set_flags step
-Projects and packages can have different flags based on repositories and architectures. With the `set_flags` step, you have the opportunity to manage flags for your projects and packages. There are OBS-wide defaults for each flag type. This step is only necessary if you want to diverge from those [defaults](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.set_flags.type).
+Projects and packages can have different flags based on repositories and architectures. With the `set_flags` step, you have the opportunity to manage flags for your projects and packages. There are OBS-wide defaults for each flag type. This step is only necessary if you want to diverge from those [defaults](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-set-flags-type).
 
 Here is a simple example of how you can use it:
 ```
@@ -30,7 +30,7 @@ workflow:
             project: home:Admin
 ```
 
-Please refer to the [documentation](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.set_flags) to learn more.
+Please refer to the [documentation](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-set-flags) to learn more.
 
 ## Improvement for Workflow Runs User Interface
 The Workflow Runs page is the most important place to debug your workflows. It helps you to detect the problems like the wrong configurations in `workflows.yml`.

--- a/_posts/development/2022-12-20-scm-integration-workflows-file.md
+++ b/_posts/development/2022-12-20-scm-integration-workflows-file.md
@@ -34,7 +34,7 @@ test_build:
 
 We are sure you will come up with a lot of interesting ways to use this. For more
 details on this feature, we invite you to read the [user
-documentation](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.placeholder_variables).
+documentation](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-placeholder-variables).
 
 ## A New Path
 

--- a/_posts/development/2023-02-20-update-on-the-scm-integration.md
+++ b/_posts/development/2023-02-20-update-on-the-scm-integration.md
@@ -28,7 +28,7 @@ We already created chapters in the user documentation around the placeholder var
 and configuration file url. But we didn't provide a real life example of what is
 possible to do with it. We caught up on it and added a new section where we explain
 what you can achieve with it by using those two features in combination.
-You can find the new chapter [here](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.use_cases.config_url_and_placeholder_variables).
+You can find the new chapter [here](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-use-cases-config-url-and-placeholder-variables).
 
 ### No Branches Filter Option for Tag Push Events
 
@@ -37,7 +37,7 @@ This was caused by the usage of the branches filter. Workflows for `tag_push` ev
 don't allow the usage of a branch filter, since the tag's do not have a reference to
 a certain branch, they a referencing a commit. Therefore we can't apply filters for
 branches in these cases. We improved the error messages for this case, so it's not silently erroring
-out without any hint of whats wrong. We also added a note in this [section](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.filters.branches_filter) of the user documentation.
+out without any hint of whats wrong. We also added a note in this [section](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-filters-branches-filter) of the user documentation.
 
 
 {% include partials/_how-to-give-us-feedback.md %}

--- a/_posts/development/2023-06-30-new-versioning-options-for-the-scm-ci-integration.md
+++ b/_posts/development/2023-06-30-new-versioning-options-for-the-scm-ci-integration.md
@@ -46,6 +46,6 @@ We just released a minor feature to be used with the new 1.1 version! An alias t
 
 # This Just Got Started
 
-We just released v1.1, but as we release more versions and features, please check the [OBS User Guide](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.workflow_version_table) to know more details about each one.
+We just released v1.1, but as we release more versions and features, please check the [OBS User Guide](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-workflow-version-table) to know more details about each one.
 
 {% include partials/_how-to-give-us-feedback.md %}

--- a/_posts/development/2023-08-08-submit-step-for-the-scm-ci-integration.md
+++ b/_posts/development/2023-08-08-submit-step-for-the-scm-ci-integration.md
@@ -19,13 +19,13 @@ workflow:
         target_project: home:jane_doe
 ```
 
-This step will submit the `ctris` package from project `games` to project `home:jane_doe` every time you trigger the token. Of course you can select to run this step on [certain events (push, pull request etc.)](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.filters.event_filter) or [only for some branches](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.filters.branches_filter) too.
+This step will submit the `ctris` package from project `games` to project `home:jane_doe` every time you trigger the token. Of course you can select to run this step on [certain events (push, pull request etc.)](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-filters-event-filter) or [only for some branches](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-filters-branches-filter) too.
 
 This is useful in many ways. For instance create a Submit Request every time you push a new commit to a branch. Or make accepting a Submit Request on OBS an approval step in your PRs CI. Or Submit Request the newest tag/release of your software.
 
 ## How Do I Learn More?
 
-For a more extensive look into this, please check the [OBS User Guide](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration#sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.submit_request).
+For a more extensive look into this, please check the [OBS User Guide](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-submit-request).
 
 And don't forget to let us know how you make use of this!
 

--- a/_posts/development/2024-07-05-workflow-run-easy-filtering-and-others.md
+++ b/_posts/development/2024-07-05-workflow-run-easy-filtering-and-others.md
@@ -34,7 +34,7 @@ GitHub currently supports two types of personal access tokens:
 - personal access tokens (classic)
 
 In OBS you can use any of them for the SCM/CI Integration. However, our documentation was not clear enough in this regard until now.
-You can learn about *fine-grained personal access tokens* [here](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration#sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_obs_with_scm),
+You can learn about *fine-grained personal access tokens* [here](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration.html#sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication-how-to-authenticate-obs-with-scm),
 which is [GitHub's recommended option](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) whenever possible.
 
 {% include partials/_how-to-give-us-feedback.md %}


### PR DESCRIPTION
## Description:

Several reachable SCM integration blog posts still linked to old `cha.obs.scm_ci_workflow_integration` fragment IDs. The current manual page still opens but those fragments now do not exist, so the browser lands at the top of the page instead of the intended section.

This PR updates 14 SCM manual links across 8 blog posts to the current manual page and fragment IDs.

## Checklist:

- [x] I built the site using `bundle exec jekyll build` with a temporary local Ruby compatibility shim required by the current Ruby toolchain.
- [x] I ran `bundle exec jekyll doctor`.

### Before the fix:

<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/5438fdde-c651-4b6b-a696-8c4205f7a566" />

<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/5877d037-e826-4128-bdcc-d3a9a68b169e" />

### After the fix:

<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/ccaf2894-c470-4aa4-b5d4-ab1f42a45319" />

<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/a59c9a17-d3b4-46f6-81a1-cad8334ef0a0" />