### PR TITLE
Force regenerate the blog/index.html

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,7 @@
 ---
 layout: secondary
 title: News about the OBS
+regenerate: true
 ---
 
 <div class="ui vertical stripe segment">


### PR DESCRIPTION
We need to regenerate this page every time, otherwise we are missing new posts from the index during development when we build with `--incremental`.

Currently, the only types of dependencies tracked are includes, assigns are not tracked. See

https://jekyllrb.com/docs/configuration/incremental-regeneration/