### PR TITLE
Drop version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   jekyll:
     image: jekyll/jekyll:4


### PR DESCRIPTION
The attribute `version` is obsolete, it will be ignored by docker compose.