### PR TITLE
Use newer jekyll version and adapt docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
   jekyll:
-    image: jekyll/jekyll:4
-    command: jekyll serve --watch --incremental --future
+    image: ruby:3.1
+    working_dir: /srv/jekyll
+    command: bash -c "bundle install && bundle exec jekyll serve --watch --incremental --future --host 0.0.0.0"
     ports:
       - 4000:4000
-    environment:
-      # use docker-compose.override.yml if your UID/GID differs...
-      JEKYLL_UID: 1000
-      JEKYLL_GID: 100
     volumes:
       - .:/srv/jekyll:Z
+      - bundle:/usr/local/bundle
+
+volumes:
+  bundle:


### PR DESCRIPTION
Move off the abandoned jekyll/jekyll image and onto a maintained ruby:3.1 image, letting Bundler drive Jekyll from the Gemfile.